### PR TITLE
feat: add CrewAI integration

### DIFF
--- a/autonomica/integrations/__init__.py
+++ b/autonomica/integrations/__init__.py
@@ -1,5 +1,8 @@
 """Integration exports."""
-from autonomica.integrations.langchain import wrap_langchain_tools
+
+def wrap_langchain_tools(*args, **kwargs):
+    from autonomica.integrations.langchain import wrap_langchain_tools as _wrap
+    return _wrap(*args, **kwargs)
 
 def wrap_crewai_tools(*args, **kwargs):
     from autonomica.integrations.crewai import wrap_crewai_tools as _wrap

--- a/autonomica/integrations/__init__.py
+++ b/autonomica/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""Integration exports."""
+from autonomica.integrations.langchain import wrap_langchain_tools
+from autonomica.integrations.crewai import wrap_crewai_tools
+
+__all__ = ["wrap_langchain_tools", "wrap_crewai_tools"]

--- a/autonomica/integrations/__init__.py
+++ b/autonomica/integrations/__init__.py
@@ -1,5 +1,8 @@
 """Integration exports."""
 from autonomica.integrations.langchain import wrap_langchain_tools
-from autonomica.integrations.crewai import wrap_crewai_tools
+
+def wrap_crewai_tools(*args, **kwargs):
+    from autonomica.integrations.crewai import wrap_crewai_tools as _wrap
+    return _wrap(*args, **kwargs)
 
 __all__ = ["wrap_langchain_tools", "wrap_crewai_tools"]

--- a/autonomica/integrations/crewai.py
+++ b/autonomica/integrations/crewai.py
@@ -1,0 +1,104 @@
+"""CrewAI integration — wrap CrewAI BaseTool with Autonomica governance."""
+from __future__ import annotations
+
+import inspect
+from typing import Any, Optional
+
+try:
+    from crewai.tools import BaseTool
+except ImportError:
+    class BaseTool:  # type: ignore
+        name: str
+        description: str
+        def _run(self, *args, **kwargs) -> Any: pass
+        async def _arun(self, *args, **kwargs) -> Any: pass
+
+from autonomica.models import ActionType, AgentAction
+
+
+class GovernedCrewAITool(BaseTool):
+    """A CrewAI BaseTool wrapped with Autonomica governance."""
+    original_tool: Any
+    autonomica: Any
+    agent_id: str
+    agent_name: str = ""
+
+    def _run(self, **kwargs: Any) -> Any:
+        action = self._build_action(kwargs)
+        decision = self.autonomica.evaluate_action_sync(action)
+        if not decision.approved:
+            return (
+                f"[AUTONOMICA] Action blocked (Mode: {decision.mode.name}). "
+                f"Risk score: {decision.risk_score.composite_score:.1f}. "
+                f"Reason: {decision.risk_score.explanation}"
+            )
+        try:
+            result = self.original_tool._run(**kwargs)
+        except Exception as exc:
+            self.autonomica.record_outcome(action.action_id, success=False, notes=str(exc))
+            raise
+        self.autonomica.record_outcome(action.action_id, success=True)
+        return result
+
+    async def _arun(self, **kwargs: Any) -> Any:
+        action = self._build_action(kwargs)
+        decision = await self.autonomica.evaluate_action(action)
+        if not decision.approved:
+            return (
+                f"[AUTONOMICA] Action blocked (Mode: {decision.mode.name}). "
+                f"Risk score: {decision.risk_score.composite_score:.1f}. "
+                f"Reason: {decision.risk_score.explanation}"
+            )
+        try:
+            if hasattr(self.original_tool, "_arun") and inspect.iscoroutinefunction(self.original_tool._arun):
+                result = await self.original_tool._arun(**kwargs)
+            else:
+                result = self.original_tool._run(**kwargs)
+        except Exception as exc:
+            self.autonomica.record_outcome(action.action_id, success=False, notes=str(exc))
+            raise
+        self.autonomica.record_outcome(action.action_id, success=True)
+        return result
+
+    def _infer_action_type(self) -> ActionType:
+        name = self.original_tool.name.lower()
+        desc = (self.original_tool.description or "").lower()
+        if any(w in name or w in desc for w in ["delete", "remove", "drop"]):
+            return ActionType.DELETE
+        if any(w in name or w in desc for w in ["send", "email", "message", "post", "notify"]):
+            return ActionType.COMMUNICATE
+        if any(w in name or w in desc for w in ["pay", "transfer", "invoice", "charge"]):
+            return ActionType.FINANCIAL
+        if any(w in name or w in desc for w in ["write", "update", "create", "insert", "set"]):
+            return ActionType.WRITE
+        return ActionType.READ
+
+    def _build_action(self, kwargs: dict) -> AgentAction:
+        return AgentAction(
+            agent_id=self.agent_id,
+            agent_name=self.agent_name or self.agent_id,
+            tool_name=self.original_tool.name,
+            tool_input=kwargs,
+            action_type=self._infer_action_type(),
+        )
+
+
+def wrap_crewai_tools(
+    tools: list[BaseTool],
+    autonomica: Any,
+    agent_id: str,
+    agent_name: str = "",
+) -> list[GovernedCrewAITool]:
+    governed = []
+    for tool in tools:
+        governed.append(
+            GovernedCrewAITool(
+                name=tool.name,
+                description=tool.description,
+                original_tool=tool,
+                autonomica=autonomica,
+                agent_id=agent_id,
+                agent_name=agent_name or agent_id,
+            )
+        )
+    return governed

--- a/autonomica/integrations/crewai.py
+++ b/autonomica/integrations/crewai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 from typing import Any, Optional
+from pydantic import ConfigDict
 
 try:
     from crewai.tools import BaseTool
@@ -18,6 +19,7 @@ from autonomica.models import ActionType, AgentAction
 
 class GovernedCrewAITool(BaseTool):
     """A CrewAI BaseTool wrapped with Autonomica governance."""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     original_tool: Any
     autonomica: Any
     agent_id: str

--- a/tests/test_crewai.py
+++ b/tests/test_crewai.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import MagicMock
+from autonomica.integrations.crewai import wrap_crewai_tools, GovernedCrewAITool
+from autonomica.models import ActionType, Decision, RiskScore, Mode
+
+class MockTool:
+    def __init__(self, name, description):
+        self.name = name
+        self.description = description
+    def _run(self, **kwargs):
+        return f"Result of {self.name}"
+
+def test_wrap_crewai_tools():
+    autonomica = MagicMock()
+    tools = [MockTool("test_tool", "A test tool")]
+    governed_tools = wrap_crewai_tools(tools, autonomica, agent_id="test_agent")
+    
+    assert len(governed_tools) == 1
+    assert isinstance(governed_tools[0], GovernedCrewAITool)
+    assert governed_tools[0].name == "test_tool"
+
+def test_governed_tool_approved():
+    autonomica = MagicMock()
+    decision = Decision(approved=True, mode=Mode.ENFORCE, risk_score=RiskScore(composite_score=0.1, explanation="Safe"))
+    autonomica.evaluate_action_sync.return_value = decision
+    
+    original_tool = MockTool("test_tool", "A test tool")
+    tools = [original_tool]
+    governed_tools = wrap_crewai_tools(tools, autonomica, agent_id="test_agent")
+    
+    result = governed_tools[0]._run(param="val")
+    assert result == "Result of test_tool"
+    autonomica.evaluate_action_sync.assert_called_once()
+    autonomica.record_outcome.assert_called_once()
+
+def test_governed_tool_blocked():
+    autonomica = MagicMock()
+    decision = Decision(approved=False, mode=Mode.ENFORCE, risk_score=RiskScore(composite_score=0.9, explanation="Dangerous"))
+    autonomica.evaluate_action_sync.return_value = decision
+    
+    original_tool = MockTool("test_tool", "A test tool")
+    tools = [original_tool]
+    governed_tools = wrap_crewai_tools(tools, autonomica, agent_id="test_agent")
+    
+    result = governed_tools[0]._run(param="val")
+    assert "[AUTONOMICA] Action blocked" in result
+    autonomica.evaluate_action_sync.assert_called_once()
+    autonomica.record_outcome.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_governed_tool_arun():
+    autonomica = MagicMock()
+    decision = Decision(approved=True, mode=Mode.ENFORCE, risk_score=RiskScore(composite_score=0.1, explanation="Safe"))
+    autonomica.evaluate_action.return_value = decision
+    
+    original_tool = MockTool("test_tool", "A test tool")
+    tools = [original_tool]
+    governed_tools = wrap_crewai_tools(tools, autonomica, agent_id="test_agent")
+    
+    result = await governed_tools[0]._arun(param="val")
+    assert result == "Result of test_tool"
+    autonomica.evaluate_action.assert_called_once()
+
+def test_action_type_inference():
+    autonomica = MagicMock()
+    tools = [
+        MockTool("delete_user", "Removes a user"),
+        MockTool("send_email", "Sends an email"),
+        MockTool("update_record", "Writes to db"),
+        MockTool("get_data", "Reads data")
+    ]
+    governed_tools = wrap_crewai_tools(tools, autonomica, agent_id="test_agent")
+    
+    assert governed_tools[0]._infer_action_type() == ActionType.DELETE
+    assert governed_tools[1]._infer_action_type() == ActionType.COMMUNICATE
+    assert governed_tools[2]._infer_action_type() == ActionType.WRITE
+    assert governed_tools[3]._infer_action_type() == ActionType.READ

--- a/tests/test_crewai.py
+++ b/tests/test_crewai.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 from autonomica.integrations.crewai import wrap_crewai_tools, GovernedCrewAITool
-from autonomica.models import ActionType, Decision, RiskScore, Mode
+from autonomica.models import ActionType, GovernanceDecision, GovernanceMode, RiskScore
 
 class MockTool:
     def __init__(self, name, description):
@@ -21,7 +21,23 @@ def test_wrap_crewai_tools():
 
 def test_governed_tool_approved():
     autonomica = MagicMock()
-    decision = Decision(approved=True, mode=Mode.ENFORCE, risk_score=RiskScore(composite_score=0.1, explanation="Safe"))
+    risk = RiskScore(
+        composite_score=0.1,
+        financial_magnitude=0.0,
+        data_sensitivity=0.0,
+        reversibility=0.0,
+        agent_track_record=0.0,
+        novelty=0.0,
+        cascade_risk=0.0,
+        explanation="Safe"
+    )
+    decision = GovernanceDecision(
+        action_id="test_id",
+        risk_score=risk,
+        mode=GovernanceMode.FULL_AUTO,
+        approved=True,
+        decision_time_ms=0.1
+    )
     autonomica.evaluate_action_sync.return_value = decision
     
     original_tool = MockTool("test_tool", "A test tool")
@@ -35,7 +51,23 @@ def test_governed_tool_approved():
 
 def test_governed_tool_blocked():
     autonomica = MagicMock()
-    decision = Decision(approved=False, mode=Mode.ENFORCE, risk_score=RiskScore(composite_score=0.9, explanation="Dangerous"))
+    risk = RiskScore(
+        composite_score=0.9,
+        financial_magnitude=0.0,
+        data_sensitivity=0.0,
+        reversibility=0.0,
+        agent_track_record=0.0,
+        novelty=0.0,
+        cascade_risk=0.0,
+        explanation="Dangerous"
+    )
+    decision = GovernanceDecision(
+        action_id="test_id",
+        risk_score=risk,
+        mode=GovernanceMode.QUARANTINE,
+        approved=False,
+        decision_time_ms=0.1
+    )
     autonomica.evaluate_action_sync.return_value = decision
     
     original_tool = MockTool("test_tool", "A test tool")
@@ -50,7 +82,23 @@ def test_governed_tool_blocked():
 @pytest.mark.asyncio
 async def test_governed_tool_arun():
     autonomica = MagicMock()
-    decision = Decision(approved=True, mode=Mode.ENFORCE, risk_score=RiskScore(composite_score=0.1, explanation="Safe"))
+    risk = RiskScore(
+        composite_score=0.1,
+        financial_magnitude=0.0,
+        data_sensitivity=0.0,
+        reversibility=0.0,
+        agent_track_record=0.0,
+        novelty=0.0,
+        cascade_risk=0.0,
+        explanation="Safe"
+    )
+    decision = GovernanceDecision(
+        action_id="test_id",
+        risk_score=risk,
+        mode=GovernanceMode.FULL_AUTO,
+        approved=True,
+        decision_time_ms=0.1
+    )
     autonomica.evaluate_action.return_value = decision
     
     original_tool = MockTool("test_tool", "A test tool")


### PR DESCRIPTION
Add `wrap_crewai_tools` helper so CrewAI users can route every tool call through Autonomica governance with a single line.

Changes:
- Added `autonomica/integrations/crewai.py` with `GovernedCrewAITool` and `wrap_crewai_tools`.
- Added tests in `tests/test_crewai.py`.
- Updated `autonomica/integrations/__init__.py` to export the new helper.

Fixes #1