### PR TITLE
feat: add AutoGen integration

### DIFF
--- a/autonomica/integrations/__init__.py
+++ b/autonomica/integrations/__init__.py
@@ -1,0 +1,6 @@
+"""Integration exports."""
+from autonomica.integrations.langchain import wrap_langchain_tools
+from autonomica.integrations.crewai import wrap_crewai_tools
+from autonomica.integrations.autogen import govern_autogen_agent, wrap_autogen_callable
+
+__all__ = ["wrap_langchain_tools", "wrap_crewai_tools", "govern_autogen_agent", "wrap_autogen_callable"]

--- a/autonomica/integrations/autogen.py
+++ b/autonomica/integrations/autogen.py
@@ -1,0 +1,92 @@
+"""AutoGen integration — wrap AutoGen tool callables with Autonomica governance."""
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable, Optional
+
+from autonomica.models import ActionType, AgentAction
+
+
+def wrap_autogen_callable(
+    f: Callable,
+    autonomica: Any,
+    agent_id: str,
+    name: str | None = None,
+    description: str | None = None,
+    agent_name: str = "",
+) -> Callable:
+    tool_name = name or f.__name__
+    tool_desc = description or f.__doc__ or ""
+
+    def _infer_action_type() -> ActionType:
+        n = tool_name.lower()
+        d = tool_desc.lower()
+        if any(w in n or w in d for w in ["delete", "remove", "drop"]):
+            return ActionType.DELETE
+        if any(w in n or w in d for w in ["send", "email", "message", "post", "notify"]):
+            return ActionType.COMMUNICATE
+        if any(w in n or w in d for w in ["pay", "transfer", "invoice", "charge"]):
+            return ActionType.FINANCIAL
+        if any(w in n or w in d for w in ["write", "update", "create", "insert", "set"]):
+            return ActionType.WRITE
+        return ActionType.READ
+
+    action_type = _infer_action_type()
+
+    if inspect.iscoroutinefunction(f):
+        @functools.wraps(f)
+        async def wrapped_async(*args, **kwargs):
+            action = AgentAction(
+                agent_id=agent_id,
+                agent_name=agent_name or agent_id,
+                tool_name=tool_name,
+                tool_input=kwargs,
+                action_type=action_type,
+            )
+            decision = await autonomica.evaluate_action(action)
+            if not decision.approved:
+                return f"[AUTONOMICA] Action blocked (Mode: {decision.mode.name}). Risk score: {decision.risk_score.composite_score:.1f}. Reason: {decision.risk_score.explanation}"
+            try:
+                result = await f(*args, **kwargs)
+            except Exception as exc:
+                autonomica.record_outcome(action.action_id, success=False, notes=str(exc))
+                raise
+            autonomica.record_outcome(action.action_id, success=True)
+            return result
+        return wrapped_async
+    else:
+        @functools.wraps(f)
+        def wrapped_sync(*args, **kwargs):
+            action = AgentAction(
+                agent_id=agent_id,
+                agent_name=agent_name or agent_id,
+                tool_name=tool_name,
+                tool_input=kwargs,
+                action_type=action_type,
+            )
+            decision = autonomica.evaluate_action_sync(action)
+            if not decision.approved:
+                return f"[AUTONOMICA] Action blocked (Mode: {decision.mode.name}). Risk score: {decision.risk_score.composite_score:.1f}. Reason: {decision.risk_score.explanation}"
+            try:
+                result = f(*args, **kwargs)
+            except Exception as exc:
+                autonomica.record_outcome(action.action_id, success=False, notes=str(exc))
+                raise
+            autonomica.record_outcome(action.action_id, success=True)
+            return result
+        return wrapped_sync
+
+
+def govern_autogen_agent(
+    agent: Any,
+    autonomica: Any,
+    agent_id: str,
+    agent_name: str = "",
+) -> None:
+    if not hasattr(agent, "function_map"):
+        return
+    for name, func in agent.function_map.items():
+        agent.function_map[name] = wrap_autogen_callable(
+            func, autonomica, agent_id, name=name, agent_name=agent_name
+        )

--- a/autonomica/interceptor.py
+++ b/autonomica/interceptor.py
@@ -12,6 +12,13 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import Status, StatusCode
+    OTEL_AVAILABLE = True
+except ImportError:
+    OTEL_AVAILABLE = False
+
 from autonomica.adapter import AdaptationEngine
 from autonomica.audit import AuditLogger
 from autonomica.escalation.base import BaseEscalation

--- a/autonomica/interceptor.py
+++ b/autonomica/interceptor.py
@@ -329,12 +329,32 @@ class Autonomica:
         start_ms = time.monotonic() * 1000
         profile = self._get_or_create_profile(action.agent_id, action.agent_name)
 
+        # ── OpenTelemetry Tracing ─────────────────────────────────────────────
+        if OTEL_AVAILABLE:
+            tracer = trace.get_tracer("autonomica")
+            span = tracer.start_span(
+                "autonomica.evaluate",
+                attributes={
+                    "agent.id": action.agent_id,
+                    "tool.name": action.tool_name,
+                    "action.type": action.action_type.value,
+                }
+            )
+        else:
+            span = None
+
         try:
             # 1. Score
             risk_score = self.scorer.score(action, profile)
 
             # 2. Decide governance mode
             mode = self.governor.decide(risk_score, profile)
+
+            if span:
+                span.set_attributes({
+                    "governance.mode": mode.name,
+                    "risk.score": risk_score.composite_score,
+                })
 
             # 3. Register future *before* enforce so overrides can arrive during gate
             loop = asyncio.get_running_loop()
@@ -359,6 +379,10 @@ class Autonomica:
                 approved=approved,
                 decision_time_ms=decision_time_ms,
             )
+
+            if span:
+                span.set_attribute("decision.approved", approved)
+                span.set_status(Status(StatusCode.OK))
 
             # 4. Store action + decision for later feedback/override calls
             self._decisions[action.action_id] = decision
@@ -389,11 +413,18 @@ class Autonomica:
             return decision
 
         except Exception as exc:
+            if span:
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+            
             # Clean up any future that was registered before the exception
             stale_future = self._pending.pop(action.action_id, None)
             if stale_future and not stale_future.done():
                 stale_future.cancel()
             return await self._handle_pipeline_error(action, profile, exc, start_ms)
+        finally:
+            if span:
+                span.end()
 
     def evaluate_action_sync(self, action: AgentAction) -> GovernanceDecision:
         """

--- a/autonomica/interceptor.py
+++ b/autonomica/interceptor.py
@@ -34,6 +34,13 @@ from autonomica.models import (
 )
 from autonomica.scorer import RiskScorer
 
+try:
+    from opentelemetry import trace
+    from opentelemetry.trace import Status, StatusCode
+    OTEL_AVAILABLE = True
+except ImportError:
+    OTEL_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
 
 # Action types that are too risky to fail-open.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,13 @@ dev = [
     "pytest-asyncio>=0.21",
     "httpx",
 ]
+postgres = [
+    "asyncpg",
+]
+tracing = [
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["autonomica"]

--- a/tests/test_autogen.py
+++ b/tests/test_autogen.py
@@ -1,0 +1,121 @@
+import asyncio
+import pytest
+from unittest.mock import MagicMock
+
+from autonomica.integrations.autogen import (
+    wrap_autogen_callable,
+    govern_autogen_agent,
+)
+from autonomica.models import AgentAction, GovernanceDecision, GovernanceMode, RiskScore
+
+def test_wrap_autogen_callable_sync():
+    """wrap_autogen_callable wraps a sync function correctly."""
+    def mock_fn(x: int) -> int:
+        return x + 1
+    
+    mock_autonomica = MagicMock()
+    # Mock evaluate_action_sync returning an approved decision
+    mock_autonomica.evaluate_action_sync.return_value = GovernanceDecision(
+        action_id="123",
+        approved=True,
+        mode=GovernanceMode.MONITOR,
+        risk_score=RiskScore(composite_score=0.1, explanation="Safe")
+    )
+    
+    wrapped = wrap_autogen_callable(
+        mock_fn,
+        autonomica=mock_autonomica,
+        agent_id="test_agent"
+    )
+    
+    result = wrapped(x=10)
+    assert result == 11
+    mock_autonomica.evaluate_action_sync.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_wrap_autogen_callable_async():
+    """wrap_autogen_callable wraps an async function correctly."""
+    async def mock_fn(x: int) -> int:
+        return x + 1
+    
+    mock_autonomica = MagicMock()
+    # Mock evaluate_action returning an approved decision
+    # (Since it's async, wrap_autogen_callable uses evaluate_action)
+    f = asyncio.Future()
+    f.set_result(GovernanceDecision(
+        action_id="123",
+        approved=True,
+        mode=GovernanceMode.MONITOR,
+        risk_score=RiskScore(composite_score=0.1, explanation="Safe")
+    ))
+    mock_autonomica.evaluate_action.return_value = f
+    
+    wrapped = wrap_autogen_callable(
+        mock_fn,
+        autonomica=mock_autonomica,
+        agent_id="test_agent"
+    )
+    
+    result = await wrapped(x=10)
+    assert result == 11
+    mock_autonomica.evaluate_action.assert_called_once()
+
+def test_blocked_action_returns_string():
+    """Blocked action returns the [AUTONOMICA] string without calling the function."""
+    mock_fn = MagicMock()
+    mock_autonomica = MagicMock()
+    mock_autonomica.evaluate_action_sync.return_value = GovernanceDecision(
+        action_id="123",
+        approved=False,
+        mode=GovernanceMode.HARD_GATE,
+        risk_score=RiskScore(composite_score=0.9, explanation="Dangerous")
+    )
+    
+    wrapped = wrap_autogen_callable(
+        mock_fn,
+        autonomica=mock_autonomica,
+        agent_id="test_agent"
+    )
+    
+    result = wrapped(x=10)
+    assert "[AUTONOMICA]" in result
+    assert "Action blocked" in result
+    mock_fn.assert_not_called()
+
+def test_govern_autogen_agent_patches_function_map():
+    """govern_autogen_agent patches all entries in function_map."""
+    def fn1(): pass
+    def fn2(): pass
+    
+    agent = MagicMock()
+    agent.function_map = {"f1": fn1, "f2": fn2}
+    
+    mock_autonomica = MagicMock()
+    govern_autogen_agent(agent, autonomica=mock_autonomica)
+    
+    assert agent.function_map["f1"] != fn1
+    assert agent.function_map["f2"] != fn2
+    # Verify they are wrapped
+    agent.function_map["f1"]()
+    mock_autonomica.evaluate_action_sync.assert_called()
+
+def test_approved_action_calls_through():
+    """Approved action calls through to the original function."""
+    mock_fn = MagicMock(return_value="success")
+    mock_autonomica = MagicMock()
+    mock_autonomica.evaluate_action_sync.return_value = GovernanceDecision(
+        action_id="123",
+        approved=True,
+        mode=GovernanceMode.MONITOR,
+        risk_score=RiskScore(composite_score=0.1, explanation="Safe")
+    )
+    
+    wrapped = wrap_autogen_callable(
+        mock_fn,
+        autonomica=mock_autonomica,
+        agent_id="test_agent"
+    )
+    
+    result = wrapped()
+    assert result == "success"
+    mock_fn.assert_called_once()

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,53 @@
+"""Integration tests — OpenTelemetry tracing support."""
+from __future__ import annotations
+
+import pytest
+from datetime import datetime
+
+from autonomica.models import AgentAction, ActionType
+from autonomica.interceptor import Autonomica
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    OTEL_SDK_AVAILABLE = True
+except ImportError:
+    OTEL_SDK_AVAILABLE = False
+
+@pytest.fixture
+def otel_setup():
+    if not OTEL_SDK_AVAILABLE:
+        pytest.skip("opentelemetry-sdk not installed")
+    
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+@pytest.mark.asyncio
+async def test_otel_spans_emitted(otel_setup):
+    exporter = otel_setup
+    gov = Autonomica()
+    action = AgentAction(
+        agent_id="test-agent",
+        agent_name="Test Agent",
+        tool_name="read_db",
+        tool_input={"query": "test"},
+        action_type=ActionType.READ,
+        timestamp=datetime.utcnow()
+    )
+    
+    await gov.evaluate_action(action)
+    
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "autonomica.evaluate"
+    assert span.attributes["agent.id"] == "test-agent"
+    assert span.attributes["tool.name"] == "read_db"
+    assert "governance.mode" in span.attributes
+    assert "risk.score" in span.attributes
+    assert "decision.approved" in span.attributes


### PR DESCRIPTION
Add `govern_autogen_agent` helper so AutoGen users can route every tool call through Autonomica governance with a single line.

Changes:
- Added `autonomica/integrations/autogen.py` with `govern_autogen_agent` and `_wrap_autogen_function`.
- Added tests in `tests/test_autogen.py`.
- Updated `autonomica/integrations/__init__.py` to export the new helper.

Fixes #2