### PR TITLE
feat: add webhook escalation backend

### DIFF
--- a/autonomica/escalation/webhook.py
+++ b/autonomica/escalation/webhook.py
@@ -1,0 +1,104 @@
+"""Webhook escalation backend — POSTs governance alerts to any HTTP endpoint.
+
+Enables integrations with PagerDuty, OpsGenie, custom dashboards, or any 
+webhook-capable service. Supports optional HMAC-SHA256 signatures for 
+verification.
+
+Usage::
+
+    from autonomica.escalation.webhook import WebhookEscalation
+
+    gov = Autonomica(
+        escalation=WebhookEscalation(
+            url="https://api.myapp.com/webhooks/autonomica",
+            secret="my-signing-secret"
+        )
+    )
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any, Dict, Optional
+
+import httpx
+
+from autonomica.escalation.base import BaseEscalation
+from autonomica.models import AgentAction, GovernanceMode, RiskScore
+
+
+class WebhookEscalation(BaseEscalation):
+    """POSTs governance events to a generic webhook endpoint.
+
+    Args:
+        url:     The HTTP(S) endpoint to POST to.
+        headers: Optional dictionary of extra HTTP headers.
+        secret:  Optional secret key for HMAC-SHA256 signing of the payload.
+                 If provided, an `X-Autonomica-Signature` header is added.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        headers: Optional[Dict[str, str]] = None,
+        secret: Optional[str] = None,
+    ) -> None:
+        self._url = url
+        self._headers = headers or {}
+        self._secret = secret
+
+    async def notify(
+        self, action: AgentAction, mode: GovernanceMode, risk_score: RiskScore
+    ) -> None:
+        """Build and POST the webhook payload."""
+        payload = {
+            "version": "1.0",
+            "timestamp": int(time.time()),
+            "action": action.model_dump(),
+            "governance": {
+                "mode": mode.name,
+                "risk_score": risk_score.model_dump(),
+            },
+        }
+
+        body = json.dumps(payload)
+        headers = self._headers.copy()
+        headers["Content-Type"] = "application/json"
+
+        if self._secret:
+            signature = hmac.new(
+                self._secret.encode("utf-8"),
+                body.encode("utf-8"),
+                hashlib.sha256
+            ).hexdigest()
+            headers["X-Autonomica-Signature"] = signature
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                # Retry once on 5xx with a 1s delay as per requirements
+                for attempt in range(2):
+                    response = await client.post(
+                        self._url,
+                        content=body,
+                        headers=headers
+                    )
+                    
+                    if response.is_success:
+                        break
+                    
+                    if attempt == 0 and response.is_server_error:
+                        time.sleep(1.0)
+                        continue
+                        
+                    response.raise_for_status()
+        except Exception:
+            # Never let a webhook failure block the governance pipeline.
+            pass
+
+    async def wait_for_response(
+        self, action_id: str, timeout: float
+    ) -> Optional[bool]:
+        """Generic webhooks are fire-and-forget; human response via API."""
+        return None

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,69 @@
+"""Webhook escalation tests — unit tests for the WebhookEscalation backend."""
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+from datetime import datetime
+
+from autonomica.models import AgentAction, ActionType, GovernanceMode, RiskScore
+from autonomica.escalation.webhook import WebhookEscalation
+
+@pytest.fixture
+def sample_action():
+    return AgentAction(
+        agent_id="test-agent",
+        agent_name="Test Agent",
+        tool_name="read_db",
+        tool_input={"query": "SELECT * FROM users"},
+        action_type=ActionType.READ,
+        timestamp=datetime.utcnow()
+    )
+
+@pytest.fixture
+def sample_risk_score():
+    return RiskScore(
+        composite_score=45.0,
+        financial_magnitude=10.0,
+        data_sensitivity=50.0,
+        reversibility=30.0,
+        agent_track_record=40.0,
+        novelty=70.0,
+        cascade_risk=20.0,
+        explanation="Medium risk due to data sensitivity."
+    )
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_webhook_notify_success(sample_action, sample_risk_score):
+    url = "https://api.test/webhook"
+    respx.post(url).respond(200)
+    
+    escalation = WebhookEscalation(url)
+    await escalation.notify(sample_action, GovernanceMode.SOFT_GATE, sample_risk_score)
+    
+    assert respx.calls.count == 1
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_webhook_with_signature(sample_action, sample_risk_score):
+    url = "https://api.test/webhook"
+    secret = "test-secret"
+    respx.post(url).respond(200)
+    
+    escalation = WebhookEscalation(url, secret=secret)
+    await escalation.notify(sample_action, GovernanceMode.SOFT_GATE, sample_risk_score)
+    
+    assert "X-Autonomica-Signature" in respx.calls.last.request.headers
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_webhook_retry_on_5xx(sample_action, sample_risk_score):
+    url = "https://api.test/webhook"
+    # Mock first call as 500, second as 200
+    respx.post(url).side_effect = [Response(500), Response(200)]
+    
+    escalation = WebhookEscalation(url)
+    await escalation.notify(sample_action, GovernanceMode.SOFT_GATE, sample_risk_score)
+    
+    assert respx.calls.count == 2


### PR DESCRIPTION
Add a generic `WebhookEscalation` backend that POSTs governance events to any HTTP endpoint — enabling integrations with PagerDuty, OpsGenie, custom dashboards, or any webhook-capable service.

Changes:
- Added `autonomica/escalation/webhook.py` implementing `BaseEscalation`.
- Configurable: `url`, `headers`, and optional `secret` for HMAC-SHA256 signatures.
- Added `X-Autonomica-Signature` header when secret is provided.
- Retries once on 5xx errors with a 1s delay.
- Payload includes serialized `AgentAction`, mode, and `RiskScore`.
- Added unit tests in `tests/test_webhook.py` using `respx`.

Fixes #4